### PR TITLE
Change `Psapi.h` to `psapi.h` to allow MinGW compilation.

### DIFF
--- a/src/stacktrace_windows.cpp
+++ b/src/stacktrace_windows.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 #include <mutex>
 #include <iomanip>
-#include <Psapi.h>
+#include <psapi.h>
 #include <tlhelp32.h>
 #include <g3log/g3log.hpp>
 


### PR DESCRIPTION
# Description

Fixes compilation with MinGW.

# Testing

- [ ] This new/modified code was covered by unit tests. 

- [ ] (insight) Was all tests written using TDD (Test Driven Development) style?

- [ ] The CI (Windows, Linux, OSX) are working without issues. 

- [ ] Was new functionality documented? 

- [ ] The testing steps  1 - 2 below were followed

_step 1_

```bash 
mkdir build; cd build; cmake -DADD_G3LOG_UNIT_TEST=ON ..

// linux/osx alternative, simply run: ./scripts/buildAndRunTests.sh
```

_step 2: use one of these alternatives to run tests:_

- Cross-Platform: `ctest`
- or `ctest -V` for verbose output
- Linux: `make test`
